### PR TITLE
fix: infinite re-entry of `MarshalJSON` method

### DIFF
--- a/.changelog/unreleased/bug-fixes/865-fix-peerstate-marshaljson.md
+++ b/.changelog/unreleased/bug-fixes/865-fix-peerstate-marshaljson.md
@@ -1,0 +1,2 @@
+- `[consensus]` Avoid recursive call after rename to (*PeerState).MarshalJSON
+  ([\#863](https://github.com/cometbft/cometbft/pull/863))

--- a/.changelog/unreleased/bug-fixes/865-fix-peerstate-marshaljson.md
+++ b/.changelog/unreleased/bug-fixes/865-fix-peerstate-marshaljson.md
@@ -1,2 +1,0 @@
-- `[consensus]` Avoid recursive call after rename to (*PeerState).MarshalJSON
-  ([\#863](https://github.com/cometbft/cometbft/pull/863))

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20.4"
+          go-version: "1.20.5"
           check-latest: true
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -1067,7 +1067,8 @@ func (ps *PeerState) MarshalJSON() ([]byte, error) {
 	ps.mtx.Lock()
 	defer ps.mtx.Unlock()
 
-	return cmtjson.Marshal(ps)
+	type jsonPeerState PeerState
+	return cmtjson.Marshal((*jsonPeerState)(ps))
 }
 
 // GetHeight returns an atomic snapshot of the PeerRoundState's height

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/libs/bits"
 	"github.com/cometbft/cometbft/libs/bytes"
+	"github.com/cometbft/cometbft/libs/json"
 	"github.com/cometbft/cometbft/libs/log"
 	cmtsync "github.com/cometbft/cometbft/libs/sync"
 	mempl "github.com/cometbft/cometbft/mempool"
@@ -1004,4 +1005,33 @@ func TestVoteSetBitsMessageValidateBasic(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMarshalJSONPeerState(t *testing.T) {
+	ps := NewPeerState(nil)
+	data, err := json.Marshal(ps)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"round_state":{
+			"height": "0",
+			"round": -1,
+			"step": 0,
+			"start_time": "0001-01-01T00:00:00Z",
+			"proposal": false,
+			"proposal_block_part_set_header":
+				{"total":0, "hash":""},
+			"proposal_block_parts": null,
+			"proposal_pol_round": -1,
+			"proposal_pol": null,
+			"prevotes": null,
+			"precommits": null,
+			"last_commit_round": -1,
+			"last_commit": null,
+			"catchup_commit_round": -1,
+			"catchup_commit": null
+		},
+		"stats":{
+			"votes":"0",
+			"block_parts":"0"}
+		}`, string(data))
 }


### PR DESCRIPTION
### Description

This pr is to fix a bug with `PeerState.MarshalJSON` method

### Rationale

This bug will cause the node down.

### Changes

Notable changes:
* rename the`MarshalJSON` method to `MarshalToJSON`
