### PR TITLE
fix: rollback LastRandaoMix was incorrect

### DIFF
--- a/state/rollback.go
+++ b/state/rollback.go
@@ -105,7 +105,7 @@ func Rollback(bs BlockStore, ss Store, removeBlock bool) (int64, []byte, error) 
 		LastResultsHash: latestBlock.Header.LastResultsHash,
 		AppHash:         latestBlock.Header.AppHash,
 
-		LastRandaoMix: latestBlock.Header.RandaoMix,
+		LastRandaoMix: rollbackBlock.Header.RandaoMix,
 	}
 
 	// persist the new state. This overrides the invalid one. NOTE: this will also

--- a/state/rollback_test.go
+++ b/state/rollback_test.go
@@ -294,7 +294,7 @@ func makeBlockIDRandom() types.BlockID {
 func makeRandaoMix() []byte {
 	// Calculate randao mix.
 	randaoMix := make([]byte, ed25519.SignatureSize)
-	rand.Read(randaoMix)
+	_, _ = rand.Read(randaoMix)
 
 	return randaoMix
 }

--- a/state/rollback_test.go
+++ b/state/rollback_test.go
@@ -10,6 +10,7 @@ import (
 	dbm "github.com/cometbft/cometbft-db"
 
 	"github.com/cometbft/cometbft/crypto"
+	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	cmtstate "github.com/cometbft/cometbft/proto/tendermint/state"
 	cmtversion "github.com/cometbft/cometbft/proto/tendermint/version"
@@ -45,6 +46,7 @@ func TestRollback(t *testing.T) {
 	nextState.ConsensusParams = *newParams
 	nextState.LastHeightConsensusParamsChanged = nextHeight + 1
 	nextState.LastHeightValidatorsChanged = nextHeight + 1
+	nextState.LastRandaoMix = makeRandaoMix()
 
 	// update the state
 	require.NoError(t, stateStore.Save(nextState))
@@ -57,6 +59,7 @@ func TestRollback(t *testing.T) {
 			AppHash:         crypto.CRandBytes(tmhash.Size),
 			LastBlockID:     makeBlockIDRandom(),
 			LastResultsHash: initialState.LastResultsHash,
+			RandaoMix:       initialState.LastRandaoMix,
 		},
 	}
 	nextBlock := &types.BlockMeta{
@@ -67,6 +70,7 @@ func TestRollback(t *testing.T) {
 			LastBlockID:     block.BlockID,
 			Time:            nextState.LastBlockTime,
 			LastResultsHash: nextState.LastResultsHash,
+			RandaoMix:       nextState.LastRandaoMix,
 		},
 	}
 	blockStore.On("LoadBlockMeta", height).Return(block)
@@ -285,4 +289,12 @@ func makeBlockIDRandom() types.BlockID {
 			Hash:  partSetHash,
 		},
 	}
+}
+
+func makeRandaoMix() []byte {
+	// Calculate randao mix.
+	randaoMix := make([]byte, ed25519.SignatureSize)
+	rand.Read(randaoMix)
+
+	return randaoMix
 }

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,7 +1,7 @@
 # We need to build in a Linux environment to support C libraries, e.g. RocksDB.
 # We use Debian instead of Alpine, so that we can use binary database packages
 # instead of spending time compiling them.
-FROM golang:1.20
+FROM golang:1.20-bullseye
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y libleveldb-dev librocksdb-dev >/dev/null


### PR DESCRIPTION
### Description
```
{"level":"error","module":"server","module":"blockchain","err":"wrong randao reveal, proposer: 4211781C8C562E7CC5B0C4E242DDEC2019D5233F, reveal: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000, len: 64, height: 65","time":"2023-06-29T15:20:37+08:00","message":"Error in validation"}
```

rollback LastRandaoMix was incorrect

### Rationale

LastRandaoMix should be set to the last block when doing a rollback, otherwise, the replayBlock will fail due to the LastRandaoMix being the same.

### Example

n/a

### Changes

Notable changes:
* rollback
* rollback_test
