### PR TITLE
chore: remove some local client's mutex

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20.5"
+          go-version: "1.20.6"
           check-latest: true
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6

--- a/abci/client/local_client.go
+++ b/abci/client/local_client.go
@@ -89,9 +89,6 @@ func (app *localClient) DeliverTxAsync(params types.RequestDeliverTx) *ReqRes {
 }
 
 func (app *localClient) CheckTxAsync(req types.RequestCheckTx) *ReqRes {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
 	res := app.Application.CheckTx(req)
 	return app.callback(
 		types.ToRequestCheckTx(req),
@@ -100,9 +97,6 @@ func (app *localClient) CheckTxAsync(req types.RequestCheckTx) *ReqRes {
 }
 
 func (app *localClient) QueryAsync(req types.RequestQuery) *ReqRes {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
 	res := app.Application.Query(req)
 	return app.callback(
 		types.ToRequestQuery(req),
@@ -247,17 +241,11 @@ func (app *localClient) DeliverTxSync(req types.RequestDeliverTx) (*types.Respon
 }
 
 func (app *localClient) CheckTxSync(req types.RequestCheckTx) (*types.ResponseCheckTx, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
 	res := app.Application.CheckTx(req)
 	return &res, nil
 }
 
 func (app *localClient) QuerySync(req types.RequestQuery) (*types.ResponseQuery, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
 	res := app.Application.Query(req)
 	return &res, nil
 }
@@ -364,9 +352,6 @@ func newLocalReqRes(req *types.Request, res *types.Response) *ReqRes {
 // -------------------------------------------------------
 
 func (app *localClient) EthQueryAsync(req types.RequestEthQuery) *ReqRes {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
 	res := app.Application.EthQuery(req)
 	return app.callback(
 		types.ToRequestEthQuery(req),
@@ -375,9 +360,6 @@ func (app *localClient) EthQueryAsync(req types.RequestEthQuery) *ReqRes {
 }
 
 func (app *localClient) EthQuerySync(req types.RequestEthQuery) (*types.ResponseEthQuery, error) {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
 	res := app.Application.EthQuery(req)
 	return &res, nil
 }


### PR DESCRIPTION
### Description

This pr is to remove some local client's mutex. It requires the greenfield-cosmos-sdk to make changes accordingly.

### Rationale

To speed up rpc query and block.

### Changes

Notable changes:
* remove mutex in local client's `Query` and `CheckTx` methods