### PR TITLE
feat: add abci responses to `ResultBlock`

### DIFF
--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -382,11 +382,11 @@ FOR_LOOP:
 			bcR.pool.PopRequest()
 
 			// TODO: batch saves so we dont persist to disk every block
-			bcR.store.SaveBlock(first, firstParts, second.LastCommit)
+			bcR.store.SaveBlock(first, firstParts, second.LastCommit, nil)
 
 			// TODO: same thing for app - but we would need a way to
 			// get the hash without persisting the state
-			state, _, err = bcR.blockExec.ApplyBlock(state, firstID, first)
+			state, _, _, err = bcR.blockExec.ApplyBlock(state, firstID, first)
 			if err != nil {
 				// TODO This is bad, are we zombie?
 				panic(fmt.Sprintf("Failed to process committed block (%d:%X): %v", first.Height, first.Hash(), err))

--- a/blocksync/reactor_test.go
+++ b/blocksync/reactor_test.go
@@ -141,12 +141,12 @@ func newReactor(
 		require.NoError(t, err)
 		blockID := types.BlockID{Hash: thisBlock.Hash(), PartSetHeader: thisParts.Header()}
 
-		state, _, err = blockExec.ApplyBlock(state, blockID, thisBlock)
+		state, _, _, err = blockExec.ApplyBlock(state, blockID, thisBlock)
 		if err != nil {
 			panic(fmt.Errorf("error apply block: %w", err))
 		}
 
-		blockStore.SaveBlock(thisBlock, thisParts, lastCommit)
+		blockStore.SaveBlock(thisBlock, thisParts, lastCommit, nil)
 	}
 
 	bcReactor := NewReactor(state.Copy(), blockExec, blockStore, fastSync)

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -500,7 +500,7 @@ func (h *Handshaker) replayBlock(state sm.State, height int64, proxyApp proxy.Ap
 	blockExec.SetEventBus(h.eventBus)
 
 	var err error
-	state, _, err = blockExec.ApplyBlock(state, meta.BlockID, block)
+	state, _, _, err = blockExec.ApplyBlock(state, meta.BlockID, block)
 	if err != nil {
 		return sm.State{}, err
 	}

--- a/evidence/pool_test.go
+++ b/evidence/pool_test.go
@@ -423,7 +423,7 @@ func initializeBlockStore(db dbm.DB, state sm.State, valAddr []byte) (*store.Blo
 		}
 
 		seenCommit := makeCommit(i, valAddr)
-		blockStore.SaveBlock(block, partSet, seenCommit)
+		blockStore.SaveBlock(block, partSet, seenCommit, nil)
 	}
 
 	return blockStore, nil

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -120,10 +120,11 @@ func Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlock, error)
 
 	block := env.BlockStore.LoadBlock(height)
 	blockMeta := env.BlockStore.LoadBlockMeta(height)
+	abciRes := env.BlockStore.LoadABCIResponses(height)
 	if blockMeta == nil {
-		return &ctypes.ResultBlock{BlockID: types.BlockID{}, Block: block}, nil
+		return &ctypes.ResultBlock{BlockID: types.BlockID{}, Block: block, ABCIResponses: abciRes}, nil
 	}
-	return &ctypes.ResultBlock{BlockID: blockMeta.BlockID, Block: block}, nil
+	return &ctypes.ResultBlock{BlockID: blockMeta.BlockID, Block: block, ABCIResponses: abciRes}, nil
 }
 
 // BlockByHash gets block by hash.
@@ -131,11 +132,12 @@ func Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlock, error)
 func BlockByHash(ctx *rpctypes.Context, hash []byte) (*ctypes.ResultBlock, error) {
 	block := env.BlockStore.LoadBlockByHash(hash)
 	if block == nil {
-		return &ctypes.ResultBlock{BlockID: types.BlockID{}, Block: nil}, nil
+		return &ctypes.ResultBlock{BlockID: types.BlockID{}, Block: nil, ABCIResponses: nil}, nil
 	}
 	// If block is not nil, then blockMeta can't be nil.
 	blockMeta := env.BlockStore.LoadBlockMeta(block.Height)
-	return &ctypes.ResultBlock{BlockID: blockMeta.BlockID, Block: block}, nil
+	abciRes := env.BlockStore.LoadABCIResponsesByHash(hash)
+	return &ctypes.ResultBlock{BlockID: blockMeta.BlockID, Block: block, ABCIResponses: abciRes}, nil
 }
 
 // Commit gets block commit at a given height.

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/libs/bytes"
 	"github.com/cometbft/cometbft/p2p"
+	cmtstate "github.com/cometbft/cometbft/proto/tendermint/state"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cometbft/cometbft/types"
 	"github.com/cometbft/cometbft/votepool"
@@ -36,8 +37,9 @@ type ResultGenesisChunk struct {
 
 // Single block (with meta)
 type ResultBlock struct {
-	BlockID types.BlockID `json:"block_id"`
-	Block   *types.Block  `json:"block"`
+	BlockID       types.BlockID           `json:"block_id"`
+	Block         *types.Block            `json:"block"`
+	ABCIResponses *cmtstate.ABCIResponses `json:"abci_responses"`
 }
 
 // ResultHeader represents the response for a Header RPC Client query
@@ -64,8 +66,8 @@ type ResultBlockResults struct {
 // NewResultCommit is a helper to initialize the ResultCommit with
 // the embedded struct
 func NewResultCommit(header *types.Header, commit *types.Commit,
-	canonical bool) *ResultCommit {
-
+	canonical bool,
+) *ResultCommit {
 	return &ResultCommit{
 		SignedHeader: types.SignedHeader{
 			Header: header,

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -66,7 +66,7 @@ func TestApplyBlock(t *testing.T) {
 	require.NoError(t, err)
 	blockID := types.BlockID{Hash: block.Hash(), PartSetHeader: bps.Header()}
 
-	state, retainHeight, err := blockExec.ApplyBlock(state, blockID, block)
+	state, retainHeight, _, err := blockExec.ApplyBlock(state, blockID, block)
 	require.Nil(t, err)
 	assert.EqualValues(t, retainHeight, 1)
 
@@ -242,7 +242,7 @@ func TestBeginBlockByzantineValidators(t *testing.T) {
 
 	blockID = types.BlockID{Hash: block.Hash(), PartSetHeader: bps.Header()}
 
-	state, retainHeight, err := blockExec.ApplyBlock(state, blockID, block)
+	state, retainHeight, _, err := blockExec.ApplyBlock(state, blockID, block)
 	require.Nil(t, err)
 	assert.EqualValues(t, retainHeight, 1)
 
@@ -564,7 +564,7 @@ func TestEndBlockValidatorUpdates(t *testing.T) {
 		{PubKey: currentValPk, Power: currentValPower, BlsKey: blsPubKey, RelayerAddress: relayer}, // updating a validator's bls pub key and addresses
 	}
 
-	state, _, err = blockExec.ApplyBlock(state, blockID, block)
+	state, _, _, err = blockExec.ApplyBlock(state, blockID, block)
 	require.Nil(t, err)
 	// test new validator was added to NextValidators
 	if assert.Equal(t, state.Validators.Size()+1, state.NextValidators.Size()) {
@@ -637,7 +637,7 @@ func TestEndBlockValidatorUpdatesResultingInEmptySet(t *testing.T) {
 		{PubKey: vp, Power: 0},
 	}
 
-	assert.NotPanics(t, func() { state, _, err = blockExec.ApplyBlock(state, blockID, block) })
+	assert.NotPanics(t, func() { state, _, _, err = blockExec.ApplyBlock(state, blockID, block) })
 	assert.NotNil(t, err)
 	assert.NotEmpty(t, state.NextValidators.Validators)
 }

--- a/state/helpers_test.go
+++ b/state/helpers_test.go
@@ -68,7 +68,7 @@ func makeAndApplyGoodBlock(state sm.State, height int64, lastCommit *types.Commi
 	}
 	blockID := types.BlockID{Hash: block.Hash(),
 		PartSetHeader: partSet.Header()}
-	state, _, err = blockExec.ApplyBlock(state, blockID, block)
+	state, _, _, err = blockExec.ApplyBlock(state, blockID, block)
 	if err != nil {
 		return state, types.BlockID{}, err
 	}

--- a/state/mocks/block_store.go
+++ b/state/mocks/block_store.go
@@ -5,6 +5,8 @@ package mocks
 import (
 	mock "github.com/stretchr/testify/mock"
 
+	tendermintstate "github.com/cometbft/cometbft/proto/tendermint/state"
+
 	types "github.com/cometbft/cometbft/types"
 )
 
@@ -50,6 +52,38 @@ func (_m *BlockStore) Height() int64 {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(int64)
+	}
+
+	return r0
+}
+
+// LoadABCIResponses provides a mock function with given fields: height
+func (_m *BlockStore) LoadABCIResponses(height int64) *tendermintstate.ABCIResponses {
+	ret := _m.Called(height)
+
+	var r0 *tendermintstate.ABCIResponses
+	if rf, ok := ret.Get(0).(func(int64) *tendermintstate.ABCIResponses); ok {
+		r0 = rf(height)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*tendermintstate.ABCIResponses)
+		}
+	}
+
+	return r0
+}
+
+// LoadABCIResponsesByHash provides a mock function with given fields: hash
+func (_m *BlockStore) LoadABCIResponsesByHash(hash []byte) *tendermintstate.ABCIResponses {
+	ret := _m.Called(hash)
+
+	var r0 *tendermintstate.ABCIResponses
+	if rf, ok := ret.Get(0).(func([]byte) *tendermintstate.ABCIResponses); ok {
+		r0 = rf(hash)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*tendermintstate.ABCIResponses)
+		}
 	}
 
 	return r0
@@ -204,9 +238,9 @@ func (_m *BlockStore) PruneBlocks(height int64) (uint64, error) {
 	return r0, r1
 }
 
-// SaveBlock provides a mock function with given fields: block, blockParts, seenCommit
-func (_m *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit) {
-	_m.Called(block, blockParts, seenCommit)
+// SaveBlock provides a mock function with given fields: block, blockParts, seenCommit, abciRes
+func (_m *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit, abciRes *tendermintstate.ABCIResponses) {
+	_m.Called(block, blockParts, seenCommit, abciRes)
 }
 
 // Size provides a mock function with given fields:

--- a/state/rollback_test.go
+++ b/state/rollback_test.go
@@ -123,7 +123,7 @@ func TestRollbackHard(t *testing.T) {
 
 	partSet, err := block.MakePartSet(types.BlockPartSizeBytes)
 	require.NoError(t, err)
-	blockStore.SaveBlock(block, partSet, &types.Commit{Height: block.Height})
+	blockStore.SaveBlock(block, partSet, &types.Commit{Height: block.Height}, nil)
 
 	currState := state.State{
 		Version: cmtstate.Version{
@@ -165,7 +165,7 @@ func TestRollbackHard(t *testing.T) {
 
 	nextPartSet, err := nextBlock.MakePartSet(types.BlockPartSizeBytes)
 	require.NoError(t, err)
-	blockStore.SaveBlock(nextBlock, nextPartSet, &types.Commit{Height: nextBlock.Height})
+	blockStore.SaveBlock(nextBlock, nextPartSet, &types.Commit{Height: nextBlock.Height}, nil)
 
 	rollbackHeight, rollbackHash, err := state.Rollback(blockStore, stateStore, true)
 	require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestRollbackHard(t *testing.T) {
 	require.Equal(t, currState, loadedState)
 
 	// resave the same block
-	blockStore.SaveBlock(nextBlock, nextPartSet, &types.Commit{Height: nextBlock.Height})
+	blockStore.SaveBlock(nextBlock, nextPartSet, &types.Commit{Height: nextBlock.Height}, nil)
 
 	params.Version.App = 11
 

--- a/state/services.go
+++ b/state/services.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	cmtstate "github.com/cometbft/cometbft/proto/tendermint/state"
 	"github.com/cometbft/cometbft/types"
 )
 
@@ -23,14 +24,16 @@ type BlockStore interface {
 	LoadBaseMeta() *types.BlockMeta
 	LoadBlockMeta(height int64) *types.BlockMeta
 	LoadBlock(height int64) *types.Block
+	LoadABCIResponses(height int64) *cmtstate.ABCIResponses
 
-	SaveBlock(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit)
+	SaveBlock(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit, abciRes *cmtstate.ABCIResponses)
 
 	PruneBlocks(height int64) (uint64, error)
 
 	LoadBlockByHash(hash []byte) *types.Block
 	LoadBlockMetaByHash(hash []byte) *types.BlockMeta
 	LoadBlockPart(height int64, index int) *types.Part
+	LoadABCIResponsesByHash(hash []byte) *cmtstate.ABCIResponses
 
 	LoadBlockCommit(height int64) *types.Commit
 	LoadSeenCommit(height int64) *types.Commit

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -177,7 +177,7 @@ func TestBlockStoreSaveLoadBlock(t *testing.T) {
 	validPartSet, err := block.MakePartSet(2)
 	require.NoError(t, err)
 	seenCommit := makeTestCommit(10, cmttime.Now())
-	bs.SaveBlock(block, partSet, seenCommit)
+	bs.SaveBlock(block, partSet, seenCommit, nil)
 	require.EqualValues(t, 1, bs.Base(), "expecting the new height to be changed")
 	require.EqualValues(t, block.Header.Height, bs.Height(), "expecting the new height to be changed")
 
@@ -299,7 +299,7 @@ func TestBlockStoreSaveLoadBlock(t *testing.T) {
 		bs, db := freshBlockStore()
 		// SaveBlock
 		res, err, panicErr := doFn(func() (interface{}, error) {
-			bs.SaveBlock(tuple.block, tuple.parts, tuple.seenCommit)
+			bs.SaveBlock(tuple.block, tuple.parts, tuple.seenCommit, nil)
 			if tuple.block == nil {
 				return nil, nil
 			}
@@ -386,7 +386,7 @@ func TestLoadBaseMeta(t *testing.T) {
 		partSet, err := block.MakePartSet(2)
 		require.NoError(t, err)
 		seenCommit := makeTestCommit(h, cmttime.Now())
-		bs.SaveBlock(block, partSet, seenCommit)
+		bs.SaveBlock(block, partSet, seenCommit, nil)
 	}
 
 	_, err = bs.PruneBlocks(4)
@@ -460,7 +460,7 @@ func TestPruneBlocks(t *testing.T) {
 		partSet, err := block.MakePartSet(2)
 		require.NoError(t, err)
 		seenCommit := makeTestCommit(h, cmttime.Now())
-		bs.SaveBlock(block, partSet, seenCommit)
+		bs.SaveBlock(block, partSet, seenCommit, nil)
 	}
 
 	assert.EqualValues(t, 1, bs.Base())
@@ -579,7 +579,7 @@ func TestLoadBlockMetaByHash(t *testing.T) {
 	partSet, err := b1.MakePartSet(2)
 	require.NoError(t, err)
 	seenCommit := makeTestCommit(1, cmttime.Now())
-	bs.SaveBlock(b1, partSet, seenCommit)
+	bs.SaveBlock(b1, partSet, seenCommit, nil)
 
 	baseBlock := bs.LoadBlockMetaByHash(b1.Hash())
 	assert.EqualValues(t, b1.Header.Height, baseBlock.Header.Height)
@@ -596,7 +596,7 @@ func TestBlockFetchAtHeight(t *testing.T) {
 	partSet, err := block.MakePartSet(2)
 	require.NoError(t, err)
 	seenCommit := makeTestCommit(10, cmttime.Now())
-	bs.SaveBlock(block, partSet, seenCommit)
+	bs.SaveBlock(block, partSet, seenCommit, nil)
 	require.Equal(t, bs.Height(), block.Header.Height, "expecting the new height to be changed")
 
 	blockAtHeight := bs.LoadBlock(bs.Height())


### PR DESCRIPTION
### Description

This pr is to add abci responses to `ResultBlock`

### Rationale

This is to make the query easier

### Changes

Notable changes:
* add abci responses to `ResultBlock`
