### PR TITLE
fix: block include nonce mismatch tx issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,4 +376,4 @@ $(BUILDDIR)/packages.txt:$(GO_TEST_FILES) $(BUILDDIR)
 split-test-packages:$(BUILDDIR)/packages.txt
 	split -d -n l/$(NUM_SPLIT) $< $<.
 test-group-%:split-test-packages
-	cat $(BUILDDIR)/packages.txt.$* | xargs go test -mod=readonly -timeout=5m -race -coverprofile=$(BUILDDIR)/$*.profile.out
+	cat $(BUILDDIR)/packages.txt.$* | xargs go test -mod=readonly -timeout=15m -race -coverprofile=$(BUILDDIR)/$*.profile.out

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -100,6 +100,10 @@ type Mempool interface {
 	SizeBytes() int64
 }
 
+// MempoolTxChecker defines a TxCheck function that will be called by the rpc and p2p
+// to make sure the sequence is written to mempool sequentially.
+type MempoolTxChecker func(req CheckTxRequest)
+
 // PreCheckFunc is an optional filter executed before CheckTx and rejects
 // transaction if false is returned. An example would be to ensure that a
 // transaction doesn't exceeded the block size.

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -100,9 +100,9 @@ type Mempool interface {
 	SizeBytes() int64
 }
 
-// MempoolTxChecker defines a TxCheck function that will be called by the rpc and p2p
+// TxChecker defines a TxCheck function that will be called by the rpc and p2p
 // to make sure the sequence is written to mempool sequentially.
-type MempoolTxChecker func(req CheckTxRequest)
+type TxChecker func(req CheckTxRequest)
 
 // PreCheckFunc is an optional filter executed before CheckTx and rejects
 // transaction if false is returned. An example would be to ensure that a

--- a/mempool/tx.go
+++ b/mempool/tx.go
@@ -1,7 +1,9 @@
 package mempool
 
 import (
+	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/p2p"
+	"github.com/cometbft/cometbft/types"
 )
 
 // TxInfo are parameters that get passed when attempting to add a tx to the
@@ -14,4 +16,12 @@ type TxInfo struct {
 
 	// SenderP2PID is the actual p2p.ID of the sender, used e.g. for logging.
 	SenderP2PID p2p.ID
+}
+
+// CheckTxRequest is a request to CheckTx.
+type CheckTxRequest struct {
+	Tx     types.Tx
+	CB     func(*abci.Response)
+	TxInfo TxInfo
+	Err    chan error
 }

--- a/mempool/v0/reactor.go
+++ b/mempool/v0/reactor.go
@@ -128,12 +128,6 @@ func (memR *Reactor) OnStart() error {
 	return nil
 }
 
-// OnStop implements p2p.BaseReactor.
-func (memR *Reactor) OnStop() {
-	close(memR.recvCh)
-	close(memR.checkTxCh)
-}
-
 // GetChannels implements Reactor by returning the list of channels for this
 // reactor.
 func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {

--- a/mempool/v0/reactor.go
+++ b/mempool/v0/reactor.go
@@ -26,7 +26,8 @@ type Reactor struct {
 	mempool *CListMempool
 	ids     *mempoolIDs
 
-	recvCh chan p2p.Envelope
+	recvCh    chan p2p.Envelope
+	checkTxCh chan mempool.CheckTxRequest
 }
 
 type mempoolIDs struct {
@@ -93,12 +94,13 @@ func newMempoolIDs() *mempoolIDs {
 }
 
 // NewReactor returns a new Reactor with the given config and mempool.
-func NewReactor(config *cfg.MempoolConfig, mempool *CListMempool) *Reactor {
+func NewReactor(config *cfg.MempoolConfig, cMempool *CListMempool) *Reactor {
 	memR := &Reactor{
-		config:  config,
-		mempool: mempool,
-		ids:     newMempoolIDs(),
-		recvCh:  make(chan p2p.Envelope, MempoolPacketChannelSize),
+		config:    config,
+		mempool:   cMempool,
+		ids:       newMempoolIDs(),
+		recvCh:    make(chan p2p.Envelope, MempoolPacketChannelSize),
+		checkTxCh: make(chan mempool.CheckTxRequest, MempoolPacketChannelSize),
 	}
 	memR.BaseReactor = *p2p.NewBaseReactor("Mempool", memR)
 	return memR
@@ -122,12 +124,14 @@ func (memR *Reactor) OnStart() error {
 		memR.Logger.Info("Tx broadcasting is disabled")
 	}
 	go memR.receiveRoutine()
+	go memR.checkTxRoutine()
 	return nil
 }
 
 // OnStop implements p2p.BaseReactor.
 func (memR *Reactor) OnStop() {
 	close(memR.recvCh)
+	close(memR.checkTxCh)
 }
 
 // GetChannels implements Reactor by returning the list of channels for this
@@ -186,23 +190,40 @@ func (memR *Reactor) receiveRoutine() {
 			if e.Src != nil {
 				txInfo.SenderP2PID = e.Src.ID()
 			}
-
-			var err error
+			errChan := make(chan error)
 			for _, tx := range protoTxs {
 				ntx := types.Tx(tx)
-				err = memR.mempool.CheckTx(ntx, nil, txInfo)
+
+				memR.checkTxCh <- mempool.CheckTxRequest{Tx: ntx, TxInfo: txInfo, Err: errChan}
+				err := <-errChan
 				if errors.Is(err, mempool.ErrTxInCache) {
 					memR.Logger.Debug("Tx already exists in cache", "tx", ntx.String())
 				} else if err != nil {
 					memR.Logger.Info("Could not check tx", "tx", ntx.String(), "err", err)
 				}
 			}
+			close(errChan)
 		default:
 			memR.Logger.Error("unknown message type", "src", e.Src, "chId", e.ChannelID, "msg", e.Message)
 			memR.Switch.StopPeerForError(e.Src, fmt.Errorf("mempool cannot handle message of type: %T", e.Message))
 			continue
 		}
 	}
+}
+
+// checkTxRoutine checks the validity of a tx and sends the result to the given callback.
+func (memR *Reactor) checkTxRoutine() {
+	for checkTxReq := range memR.checkTxCh {
+		err := memR.mempool.CheckTx(checkTxReq.Tx, checkTxReq.CB, checkTxReq.TxInfo)
+		if checkTxReq.Err != nil {
+			checkTxReq.Err <- err
+		}
+	}
+}
+
+// CheckTx implements mempool.MempoolTxChecker by sending the tx to the checkTxRoutine.
+func (memR *Reactor) CheckTx(req mempool.CheckTxRequest) {
+	memR.checkTxCh <- req
 }
 
 // PeerState describes the state of a peer.

--- a/node/node.go
+++ b/node/node.go
@@ -229,6 +229,7 @@ type Node struct {
 	bcReactor         p2p.Reactor       // for block-syncing
 	mempoolReactor    p2p.Reactor       // for gossipping transactions
 	mempool           mempl.Mempool
+	mempoolTxChecker  mempl.MempoolTxChecker
 	votePoolReactor   p2p.Reactor // for gossipping votes signed in bls schema
 	votePool          votepool.VotePool
 	stateSync         bool                    // whether the node should state sync on startup
@@ -388,7 +389,7 @@ func createMempoolAndMempoolReactor(
 	state sm.State,
 	memplMetrics *mempl.Metrics,
 	logger log.Logger,
-) (mempl.Mempool, p2p.Reactor) {
+) (mempl.Mempool, mempl.MempoolTxChecker, p2p.Reactor) {
 	switch config.Mempool.Version {
 	case cfg.MempoolV1:
 		mp := mempoolv1.NewTxMempool(
@@ -409,7 +410,7 @@ func createMempoolAndMempoolReactor(
 			mp.EnableTxsAvailable()
 		}
 
-		return mp, reactor
+		return mp, nil, reactor
 
 	case cfg.MempoolV0:
 		mp := mempoolv0.NewCListMempool(
@@ -431,10 +432,10 @@ func createMempoolAndMempoolReactor(
 			mp.EnableTxsAvailable()
 		}
 
-		return mp, reactor
+		return mp, reactor.CheckTx, reactor
 
 	default:
-		return nil, nil
+		return nil, nil, nil
 	}
 }
 
@@ -838,7 +839,7 @@ func NewNode(config *cfg.Config,
 	logNodeStartupInfo(state, pubKey, logger, consensusLogger)
 
 	// Make MempoolReactor
-	mempool, mempoolReactor := createMempoolAndMempoolReactor(config, proxyApp, state, memplMetrics, logger)
+	mempool, mempoolTxChecker, mempoolReactor := createMempoolAndMempoolReactor(config, proxyApp, state, memplMetrics, logger)
 
 	// Make Evidence Reactor
 	evidenceReactor, evidencePool, err := createEvidenceReactor(config, dbProvider, stateDB, blockStore, logger)
@@ -964,6 +965,7 @@ func NewNode(config *cfg.Config,
 		bcReactor:        bcReactor,
 		mempoolReactor:   mempoolReactor,
 		mempool:          mempool,
+		mempoolTxChecker: mempoolTxChecker,
 		votePoolReactor:  votePoolReactor,
 		votePool:         votePool,
 		consensusState:   consensusState,
@@ -1137,6 +1139,7 @@ func (n *Node) ConfigureRPC() error {
 		ConsensusReactor: n.consensusReactor,
 		EventBus:         n.eventBus,
 		Mempool:          n.mempool,
+		MempoolTxChecker: n.mempoolTxChecker,
 		VotePool:         n.votePool,
 
 		Logger: n.Logger.With("module", "rpc"),

--- a/node/node.go
+++ b/node/node.go
@@ -229,7 +229,7 @@ type Node struct {
 	bcReactor         p2p.Reactor       // for block-syncing
 	mempoolReactor    p2p.Reactor       // for gossipping transactions
 	mempool           mempl.Mempool
-	mempoolTxChecker  mempl.MempoolTxChecker
+	mempoolTxChecker  mempl.TxChecker
 	votePoolReactor   p2p.Reactor // for gossipping votes signed in bls schema
 	votePool          votepool.VotePool
 	stateSync         bool                    // whether the node should state sync on startup
@@ -389,7 +389,7 @@ func createMempoolAndMempoolReactor(
 	state sm.State,
 	memplMetrics *mempl.Metrics,
 	logger log.Logger,
-) (mempl.Mempool, mempl.MempoolTxChecker, p2p.Reactor) {
+) (mempl.Mempool, mempl.TxChecker, p2p.Reactor) {
 	switch config.Mempool.Version {
 	case cfg.MempoolV1:
 		mp := mempoolv1.NewTxMempool(

--- a/rpc/core/env.go
+++ b/rpc/core/env.go
@@ -97,6 +97,7 @@ type Environment struct {
 	ConsensusReactor *consensus.Reactor
 	EventBus         *types.EventBus // thread safe
 	Mempool          mempl.Mempool
+	MempoolTxChecker mempl.MempoolTxChecker
 	VotePool         votepool.VotePool
 
 	Logger log.Logger

--- a/rpc/core/env.go
+++ b/rpc/core/env.go
@@ -97,7 +97,7 @@ type Environment struct {
 	ConsensusReactor *consensus.Reactor
 	EventBus         *types.EventBus // thread safe
 	Mempool          mempl.Mempool
-	MempoolTxChecker mempl.MempoolTxChecker
+	MempoolTxChecker mempl.TxChecker
 	VotePool         votepool.VotePool
 
 	Logger log.Logger


### PR DESCRIPTION
### Description

fix block include nonce mismatch tx issue

### Rationale

Currently, there are two possible concurrent invocations of the CheckTx method. The first one is an RPC invocation, and the second one is the simultaneous invocation through different P2P connections.

However, in reality, CheckTx first calls ABCI for basic validation within Cosmos, and upon receiving the cometbft response, it writes to the mempool. The process is illustrated as follows:
1.  `mem.proxyAppConn.CheckTxAsync` call ABCI 
2. `reqRes.SetCallback(mem.reqResCb(tx, txInfo.SenderID, txInfo.SenderP2PID, cb))` write `Tx` into mempool
<img width="789" alt="image" src="https://github.com/bnb-chain/greenfield-cometbft/assets/25412254/cc2a7cb2-82be-4496-9299-b084ceeb903a">

However, this creates a problem. When the CPU is particularly busy, if concurrent operations occur here, the temporary scheduling of Goroutines may cause the order of writing to the mempool after ABCI check to be incorrect. Ultimately, this results in incorrect transaction order when packaging blocks.

Therefore, we must ensure that all transaction "checking" and "writing" are executed sequentially. In this PR modification, a channel is introduced to execute transaction requests received from both P2P and RPC in a sequential manner, guaranteeing the correct order of writing to the mempool.

### Example

add an example CLI or API response...

### Changes

Notable changes:
* rpc, p2p, mempool
