### PR TITLE
fix: trim the prefix `0` for eth_chainId

### DIFF
--- a/rpc/jsonrpc/types/types.go
+++ b/rpc/jsonrpc/types/types.go
@@ -255,9 +255,17 @@ func NewEthRPCSuccessResponse(id jsonrpcid, res interface{}, method string) RPCR
 		}
 
 		switch method {
-		// return hex string for eth_blockNumber, eth_chainId, eth_networkId, eth_getBalance
-		case EthBlockNumber, EthChainID, EthNetworkID, EthGetBalance:
+		// return hex string for eth_blockNumber, eth_networkId, eth_getBalance
+		case EthBlockNumber, EthNetworkID, EthGetBalance:
 			result, err = json.Marshal("0x" + hex.EncodeToString(bz))
+			if err != nil {
+				return RPCInternalError(id, fmt.Errorf("error decode response: %w", err))
+			}
+		// return hex string for eth_chainId
+		case EthChainID:
+			// metamask do not support the Hex signed 2's complement, need to trim the prefix `0`
+			chainIDStr := strings.TrimLeft(hex.EncodeToString(bz), "0")
+			result, err = json.Marshal("0x" + chainIDStr)
 			if err != nil {
 				return RPCInternalError(id, fmt.Errorf("error decode response: %w", err))
 			}


### PR DESCRIPTION
### Description

fix: trim the prefix `0` for eth_chainId

### Rationale

<img width="442" alt="image" src="https://github.com/bnb-chain/greenfield-cometbft/assets/25412254/198fc80e-ad6f-4cef-9966-3e8b067a22f8">

**after fix:**
<img width="432" alt="image" src="https://github.com/bnb-chain/greenfield-cometbft/assets/25412254/0612be2e-4dde-416c-8821-119df1f3e5de">


### Example

add an example CLI or API response...

### Changes

Notable changes:
* rpc