### PR TITLE
fix: replay issue with mock app

### DIFF
--- a/consensus/replay_stubs.go
+++ b/consensus/replay_stubs.go
@@ -87,6 +87,11 @@ func (mock *mockProxyApp) DeliverTx(req abci.RequestDeliverTx) abci.ResponseDeli
 	return *r
 }
 
+func (mock *mockProxyApp) BeginBlock(req abci.RequestBeginBlock) abci.ResponseBeginBlock {
+	mock.txCount = 0
+	return *mock.abciResponses.BeginBlock
+}
+
 func (mock *mockProxyApp) EndBlock(req abci.RequestEndBlock) abci.ResponseEndBlock {
 	mock.txCount = 0
 	return *mock.abciResponses.EndBlock


### PR DESCRIPTION
### Description

Cometbft's implementation misses the `BeginBlock`.

### Rationale

Fix issue

### Example

NA

### Changes

Notable changes:
* replay with mock app