### PR TITLE
release: draft release for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v1.0.0
+This release includes 1 bugfix.
+
+Bugfixes:
+* [#36](https://github.com/bnb-chain/greenfield-cometbft/pull/36) fix: trim the prefix 0 for eth_chainId
+
+
 ## v0.0.3
 This release includes the features and bugfixes in the v0.0.3 alpha versions and 1 new bugfix.
 


### PR DESCRIPTION
### Description

This release drafts v1.0.0, which includes 1 bugfix.

Bugfixes:
* [#36](https://github.com/bnb-chain/greenfield-cometbft/pull/36) fix: trim the prefix 0 for eth_chainId

### Rationale

Release

### Example

NA

### Changes

Notable changes:
* change log
