### PR TITLE
release: prepare release for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v1.0.0
+This release includes 1 bugfix.
+
+Bugfixes:
+* [#36](https://github.com/bnb-chain/greenfield-cometbft/pull/36) fix: trim the prefix 0 for eth_chainId
+
+
 ## v0.0.3
 This release includes the features and bugfixes in the v0.0.3 alpha versions and 1 new bugfix.
 

--- a/rpc/jsonrpc/types/types.go
+++ b/rpc/jsonrpc/types/types.go
@@ -255,9 +255,17 @@ func NewEthRPCSuccessResponse(id jsonrpcid, res interface{}, method string) RPCR
 		}
 
 		switch method {
-		// return hex string for eth_blockNumber, eth_chainId, eth_networkId, eth_getBalance
-		case EthBlockNumber, EthChainID, EthNetworkID, EthGetBalance:
+		// return hex string for eth_blockNumber, eth_networkId, eth_getBalance
+		case EthBlockNumber, EthNetworkID, EthGetBalance:
 			result, err = json.Marshal("0x" + hex.EncodeToString(bz))
+			if err != nil {
+				return RPCInternalError(id, fmt.Errorf("error decode response: %w", err))
+			}
+		// return hex string for eth_chainId
+		case EthChainID:
+			// metamask do not support the Hex signed 2's complement, need to trim the prefix `0`
+			chainIDStr := strings.TrimLeft(hex.EncodeToString(bz), "0")
+			result, err = json.Marshal("0x" + chainIDStr)
 			if err != nil {
 				return RPCInternalError(id, fmt.Errorf("error decode response: %w", err))
 			}


### PR DESCRIPTION
### Description

This pr will release v1.0.0, which includes 1 bugfix.

Bugfixes:
* [#36](https://github.com/bnb-chain/greenfield-cometbft/pull/36) fix: trim the prefix 0 for eth_chainId

### Rationale

Release

### Example

NA

### Changes

Notable changes:
* NA
