### PR TITLE
release: draft release for v1.1.0  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v1.1.0
+This release supports 6 new json rpc queries and also resolves a replay issue.
+
+Features:
+* [#42](https://github.com/bnb-chain/greenfield-cometbft/pull/42) feat: add support for some json rpc queries
+
+Bugfixes:
+* [#37](https://github.com/bnb-chain/greenfield-cometbft/pull/37) fix: replay issue with mock app
+
+
 ## v1.0.0
 This release includes 1 bugfix.
 


### PR DESCRIPTION
### Description

This release supports 6 new json rpc queries and also resolves a replay issue.

### Rationale

Features:
* [#42](https://github.com/bnb-chain/greenfield-cometbft/pull/42) feat: add support for some json rpc queries

Bugfixes:
* [#37](https://github.com/bnb-chain/greenfield-cometbft/pull/37) fix: replay issue with mock app

### Example

Please refer to individual PRs for detailed information.

### Changes

Notable changes:
none  
