### PR TITLE
use bls instead of blst to fix opBNB bls cgo issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -163,6 +163,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/herumi/bls-eth-go-binary v0.0.0-20210917013441-d37c07cfda4e // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -730,6 +730,7 @@ github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0m
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/herumi/bls-eth-go-binary v0.0.0-20210130185500-57372fb27371/go.mod h1:luAnRm3OsMQeokhGzpYmc0ZKwawY7o87PUEP11Z7r7U=
+github.com/herumi/bls-eth-go-binary v0.0.0-20210917013441-d37c07cfda4e h1:wCMygKUQhmcQAjlk2Gquzq6dLmyMv2kF+llRspoRgrk=
 github.com/herumi/bls-eth-go-binary v0.0.0-20210917013441-d37c07cfda4e/go.mod h1:luAnRm3OsMQeokhGzpYmc0ZKwawY7o87PUEP11Z7r7U=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=

--- a/votepool/verifier.go
+++ b/votepool/verifier.go
@@ -3,7 +3,7 @@ package votepool
 import (
 	"errors"
 
-	"github.com/prysmaticlabs/prysm/crypto/bls/blst"
+	"github.com/prysmaticlabs/prysm/crypto/bls"
 
 	"github.com/cometbft/cometbft/libs/sync"
 	"github.com/cometbft/cometbft/types"
@@ -86,11 +86,11 @@ func (b *BlsSignatureVerifier) Validate(vote *Vote) error {
 }
 
 func verifySignature(msg []byte, pubKey, sig []byte) bool {
-	blsPubKey, err := blst.PublicKeyFromBytes(pubKey)
+	blsPubKey, err := bls.PublicKeyFromBytes(pubKey)
 	if err != nil {
 		return false
 	}
-	signature, err := blst.SignatureFromBytes(sig)
+	signature, err := bls.SignatureFromBytes(sig)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
### Description

opBNB supported the pre-complied contract of greenfield at https://github.com/bnb-chain/op-geth/pull/7, but the greenfield cometbft code introduced by this PR will prevent the compilation of the MIPS instruction set. It is necessary to solve this problem to support MIPS instruction set compilation in order to support Fault Proof.

### Rationale

In fact, using bls instead of blst will give me the opportunity to compile the MIPS instruction set using a pure Go implementation instead of the CGO implementation inside blst. So I replaced the corresponding places with using bls. bls will call the same-named method in blst, so they are equivalent.

### Example

none

### Changes

Notable changes:
* Use bls instead of blst
* ...
