### PR TITLE
crypto/secp256k1: use new interface SignCompact

### DIFF
--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -128,10 +128,7 @@ func GenPrivKeySecp256k1(secret []byte) PrivKey {
 func (privKey PrivKey) Sign(msg []byte) ([]byte, error) {
 	priv, _ := secp256k1.PrivKeyFromBytes(privKey)
 
-	sig, err := ecdsa.SignCompact(priv, crypto.Sha256(msg), false)
-	if err != nil {
-		return nil, err
-	}
+	sig := ecdsa.SignCompact(priv, crypto.Sha256(msg), false)
 
 	// remove the first byte which is compactSigRecoveryCode
 	return sig[1:], nil


### PR DESCRIPTION
### Description

crypto/secp256k1: use new interface SignCompact

### Rationale

btcec break api

[remove error return value for SignCompact](https://github.com/btcsuite/btcd/pull/2211)

It's safe just remove the returned error

### Example

add an example CLI or API response...

### Changes

Notable changes:
* add each change in a bullet point here
* ...
